### PR TITLE
Remove getPatient() trigger from MPI sync advice 

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSynchronizationAdvice.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSynchronizationAdvice.java
@@ -52,11 +52,6 @@ public class PatientSynchronizationAdvice implements AfterReturningAdvice {
 			PatientUpdateWorker worker = new PatientUpdateWorker(patientExport, Context.getUserContext());
 			worker.start();
 		}
-		else if(method.getName().equals("getPatient"))
-		{
-			PatientSyncWorker worker = new PatientSyncWorker(((Patient)returnValue), Context.getUserContext());
-			worker.start();
-		}
 		else if(method.getName().equals("saveGlobalProperty"))
 			MpiClientConfiguration.getInstance().clearCache();
 		else if(method.getName().equals("mergePatients") && target instanceof PatientService) {


### PR DESCRIPTION
  ### Problem                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                              
  The `PatientSynchronizationAdvice` and `EncounterSynchronizationAdvice` AOP classes fire unconditionally on every `PatientService.savePatient()`, `PatientService.getPatient()`, and `EncounterService.saveEncounter()` call. When no MPI endpoint is configured or the endpoint is unreachable, this produces thousands of errors per day: 
                                                                                                                                                                                                                                                                                                                                              
```
  ERROR - PatientSyncWorker.run(130) | org.hibernate.LazyInitializationException: could not initialize proxy - no Session                                                                                                                                                                                                                     
  ERROR - FhirMpiClientServiceImpl.exportPatient(567) | Error in FHIR PIX message                                                                                                                                                                                                                                                             
    ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException: Failed to parse response from server when performing POST to URL https://openhim.sedish.ht/CR/fhir/Patient?_format=json - java.net.UnknownHostException: openhim.sedish.ht 
```                                                                                             
                                                                                                                                                                                                                                                                                                                                              
  Production logs show **22,000+ PatientSyncWorker errors** and **155 FHIR export errors** per day on instances where MPI is not in use.                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                              
  ### Fix                                                   
                                                                                                                                                                                                                                                                                                                                              
  Both advice classes now check if `mpi-client.endpoint.cr.addr` is set before proceeding. If the property is empty or null, they return immediately with no overhead.                                                                                                                                                                        
   
  Also cleared the hardcoded default CR endpoint (`https://openhim.sedish-haiti.org/CR/fhir`) in `config.xml` so fresh installs don't ship with a URL that may be unreachable.                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                            
  ### How to enable/disable                                                                                                                                                                                                                                                                                                                   
                                                            
  - **Disable MPI sync:** leave `mpi-client.endpoint.cr.addr` empty (now the default)                                                                                                                                                                                                                                                         
  - **Enable MPI sync:** set `mpi-client.endpoint.cr.addr` to the CR endpoint URL