### PR TITLE
Skip MPI sync when CR endpoint is not configured

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/EncounterSynchronizationAdvice.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/EncounterSynchronizationAdvice.java
@@ -46,6 +46,11 @@ public class EncounterSynchronizationAdvice implements AfterReturningAdvice {
      * @see AfterReturningAdvice#afterReturning(Object, Method, Object[], Object)
      */
     public void afterReturning(Object returnValue, Method method, Object[] args, Object target) throws Throwable {
+        String crEndpoint = Context.getAdministrationService().getGlobalProperty("mpi-client.endpoint.cr.addr");
+        if (crEndpoint == null || crEndpoint.trim().isEmpty()) {
+            return;
+        }
+
         if (method.getName().equals("saveEncounter") && target instanceof EncounterService) {
             org.openmrs.Encounter encounter = (Encounter) returnValue;
             if(encounter.getObsAtTopLevel(false).size() > 0){

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSynchronizationAdvice.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSynchronizationAdvice.java
@@ -44,8 +44,11 @@ public class PatientSynchronizationAdvice implements AfterReturningAdvice {
 	 * @see org.springframework.aop.AfterReturningAdvice#afterReturning(java.lang.Object, java.lang.reflect.Method, java.lang.Object[], java.lang.Object)
 	 */
 	public void afterReturning(Object returnValue, Method method, Object[] args, Object target) throws Throwable {
-		
-		
+		String crEndpoint = Context.getAdministrationService().getGlobalProperty("mpi-client.endpoint.cr.addr");
+		if (crEndpoint == null || crEndpoint.trim().isEmpty()) {
+			return;
+		}
+
 		if(method.getName().equals("savePatient") && target instanceof PatientService)
 		{
 			MpiPatientExport patientExport = new MpiPatientExport((Patient)returnValue,null,null,null,null);


### PR DESCRIPTION
## Problem

The AOP advice classes fire on every `PatientService.savePatient()`, `PatientService.getPatient()`, and `EncounterService.saveEncounter()` call, spawning background worker threads that attempt to sync with the MPI — even when no MPI endpoint is configured or the endpoint is unreachable. This produces 22,000+ errors per day on production:

**PatientSyncWorker (triggered by getPatient):**
```
ERROR - PatientSyncWorker.run(130) | org.openmrs.api.APIAuthenticationException: Privileges required: Get Identifier Types
ERROR - PatientSyncWorker.run(130) | org.hibernate.LazyInitializationException: could not initialize proxy - no Session
```

**PatientUpdateWorker (triggered by savePatient):**
```
ERROR - FhirMpiClientServiceImpl.exportPatient(567) | Error in FHIR PIX message
ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException: Failed to parse response from server
  when performing POST to URL https://openhim.sedish.ht/CR/fhir/Patient?_format=json
  - java.net.UnknownHostException: openhim.sedish.ht: Name or service not known
```

**EncounterSynchronizationAdvice (triggered by saveEncounter):**
Each encounter save with observations blocks a thread for 15 seconds and then fails with the same connection errors.

## Fix

Both AOP advice classes (`PatientSynchronizationAdvice` and `EncounterSynchronizationAdvice`) now check `mpi-client.endpoint.cr.addr` at the top of `afterReturning()`. If the endpoint is not configured, they return immediately — no worker threads are spawned.

This is the single entry point for all MPI operations. Sites with MPI configured are unaffected — the check passes and the workers run as before. Sites without MPI get zero overhead.

## Changes

- `PatientSynchronizationAdvice.java` — check CR endpoint before spawning workers
- `EncounterSynchronizationAdvice.java` — check CR endpoint before spawning workers