### PR TITLE
Fix APIAuthenticationException in PatientSyncWorker and PatientUpdateWorker

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSyncWorker.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientSyncWorker.java
@@ -75,6 +75,11 @@ public class PatientSyncWorker extends Thread {
 			
 			Context.openSession();
 			Context.setUserContext(this.m_userContext);
+			Context.addProxyPrivilege("Get Identifier Types");
+			Context.addProxyPrivilege("Get Patients");
+			Context.addProxyPrivilege("Get Patient Identifiers");
+			Context.addProxyPrivilege("Edit Patient Identifiers");
+			Context.addProxyPrivilege("Add Patient Identifiers");
 			MpiClientService hieService = Context.getService(MpiClientService.class);
 			// Grab the national health ID for the patient
 			if(this.m_configuration.getAutomaticCrossReferenceDomains() != null) {
@@ -130,10 +135,15 @@ public class PatientSyncWorker extends Thread {
 			log.error(e);
 		}		
 		finally {
+			Context.removeProxyPrivilege("Get Identifier Types");
+			Context.removeProxyPrivilege("Get Patients");
+			Context.removeProxyPrivilege("Get Patient Identifiers");
+			Context.removeProxyPrivilege("Edit Patient Identifiers");
+			Context.removeProxyPrivilege("Add Patient Identifiers");
 			synchronized (s_xref) {
 				s_xref.remove(this.m_patient.getUuid());
 			}
-			
+
 			Context.closeSession();
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientUpdateWorker.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientUpdateWorker.java
@@ -68,6 +68,11 @@ public class PatientUpdateWorker extends Thread {
 		try {
 			Context.openSession();
 			Context.setUserContext(this.m_userContext);
+			Context.addProxyPrivilege("Get Identifier Types");
+			Context.addProxyPrivilege("Get Patients");
+			Context.addProxyPrivilege("Get Patient Identifiers");
+			Context.addProxyPrivilege("Edit Patient Identifiers");
+			Context.addProxyPrivilege("Add Patient Identifiers");
 			MpiClientService hieService = Context.getService(MpiClientService.class);
 
 			hieService.exportPatient(this.mpiPatientExport);
@@ -118,6 +123,11 @@ public class PatientUpdateWorker extends Thread {
 		} catch (MpiClientException e) {
 			log.error(e);
 		} finally {
+			Context.removeProxyPrivilege("Get Identifier Types");
+			Context.removeProxyPrivilege("Get Patients");
+			Context.removeProxyPrivilege("Get Patient Identifiers");
+			Context.removeProxyPrivilege("Edit Patient Identifiers");
+			Context.removeProxyPrivilege("Add Patient Identifiers");
 			Context.closeSession();
 		}
 	}


### PR DESCRIPTION
## Summary
Add `Context.addProxyPrivilege()` calls for required privileges in both `PatientSyncWorker` and `PatientUpdateWorker`.

Both workers run in a raw `Thread` using `Context.setUserContext()` but never elevate privileges, causing:
```
ERROR - PatientSyncWorker.run(130)
org.openmrs.api.APIAuthenticationException: Privileges required: Get Identifier Types
```
on every patient sync attempt.

## Changes
- Add proxy privileges before API calls: `Get Identifier Types`, `Get Patients`, `Get Patient Identifiers`, `Edit Patient Identifiers`, `Add Patient Identifiers`
- Remove proxy privileges in the `finally` block
- Applied to both `PatientSyncWorker.java` and `PatientUpdateWorker.java`

## Note
This PR is based on the `v1.1.4` tag because `main` has pre-existing compilation errors (duplicate `getPatientList` method definitions, `parseFhirPatient` signature mismatch) that prevent building.