### PR TITLE
Fix CI workflow and remove duplicate method definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,52 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
   release:
     types: [ created ]
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 8.0.232
+          java-version: 8
+          distribution: temurin
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
+
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.6.3
+
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "github-packages",
-                "username": "${{ secrets.RELEASE_USERNAME }}",
-                "password": "${{ secrets.RELEASE_TOKEN }}"
-            }]
-          properties: |
-            [
-              { "maven.wagon.http.ssl.insecure": "true" },
-              { "maven.wagon.http.ssl.allowall": "true" },
-              { "maven.wagon.http.ssl.ignore.validity.dates": "true"}
-            ]
-          githubServer: false
+
       - name: Build with Maven
-        run: mvn -P 'github-packages' install
-      - run: echo "event name is:" ${{ github.event_name }} 
-      - run: echo "event type is:" ${{ github.event.action }} 
+        run: >
+          mvn -P 'github-packages' install
+          -Dmaven.wagon.http.ssl.insecure=true
+          -Dmaven.wagon.http.ssl.allowall=true
+          -Dmaven.wagon.http.ssl.ignore.validity.dates=true
+
       - name: Publish package
+        if: github.event_name == 'release' && github.event.action == 'created'
         run: mvn -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true -B deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        if: github.event_name == 'release' && github.event.action == 'created'
+          RELEASE_USERNAME: ${{ secrets.RELEASE_USERNAME }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
@@ -111,10 +111,4 @@ public interface MpiClientService extends OpenmrsService {
      */
     public AuditLogger getAuditLogger();
 
-	/**
-	 * Get patient using specified identifier and AA
-	 */
-	List<MpiPatient> getPatientList(String identifier, String assigningAuthority) throws MpiClientException;
-
-
 }

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientWorker.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientWorker.java
@@ -93,10 +93,4 @@ public interface MpiClientWorker  {
 	 */
 	public AuditLogger getAuditLogger();
 
-	/**
-	 * Retrieves a list of patient from the MPI given their identifier
-	 */
-	List<MpiPatient> getPatientList(String identifier, String assigningAuthority) throws MpiClientException;
-
-
 }

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -443,7 +443,7 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 
             for (BundleEntryComponent result : results.getEntry()) {
                 org.hl7.fhir.r4.model.Patient pat = (org.hl7.fhir.r4.model.Patient) result.getResource();
-                MpiPatient mpiPatient = fhirUtil.parseFhirPatient(pat);
+                MpiPatient mpiPatient = fhirUtil.parseFhirPatient(pat, patientTranslator.toOpenmrsType(pat));
                 mpiPatientList.add(mpiPatient);
                 
             }

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
@@ -136,18 +136,6 @@ public class MpiClientServiceImpl extends BaseOpenmrsService
     }
 
     /**
-     * Get patient using specified identifier and AA
-     */
-    @Override
-    public List<MpiPatient> getPatientList(String identifier, String assigningAuthority) throws MpiClientException {
-        // TODO Auto-generated method stub
-        if (MpiClientConfiguration.getInstance().getMessageFormat().equals("fhir"))
-            return this.m_fhirService.getPatientList(identifier, assigningAuthority);
-        else
-        	return this.m_hl7Service.getPatientList(identifier, assigningAuthority);
-    }
-    
-    /**
      * Resolve patient identifier
      */
     @Override


### PR DESCRIPTION
## Summary

- **Update deprecated GitHub Actions** that cause CI failures:
  - `actions/checkout` v2 → v4
  - `actions/setup-java` v1 → v4 (with `temurin` distribution)
  - `actions/cache` v2 → v4
  - `stCarolas/setup-maven` v4 → v5
  - Replace `s4u/maven-settings-action` with `setup-java` built-in Maven server config
- **Remove duplicate `getPatientList()` method definitions** in `MpiClientService`, `MpiClientWorker`, and `MpiClientServiceImpl` that cause Java compilation errors
- **Fix `parseFhirPatient()` call signature** in `FhirMpiClientServiceImpl.getPatientList()` — was passing 1 arg, method requires 2

## Test plan

- [ ] CI workflow runs successfully on push/PR
- [ ] `mvn package` compiles and all tests pass