### PR TITLE
Fix deploy: skip parent POM to avoid 409 conflict on GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '8.0.242'
           distribution: zulu
           cache: maven
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
 
       - name: Build and test
         run: mvn -B -U clean install
@@ -34,7 +37,7 @@ jobs:
 
       - name: Publish package
         if: github.event_name == 'release' && github.event.action == 'created'
-        run: mvn -B -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
         env:
-          RELEASE_USERNAME: ${{ secrets.RELEASE_USERNAME }}
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_USERNAME: ${{ github.actor }}
+          RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v6
@@ -22,6 +23,9 @@ jobs:
           java-version: '8.0.242'
           distribution: zulu
           cache: maven
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
 
       - name: Set release version
         run: |
@@ -30,6 +34,12 @@ jobs:
 
       - name: Build
         run: mvn -B clean package -DskipTests
+
+      - name: Publish to GitHub Packages
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
+        env:
+          RELEASE_USERNAME: ${{ github.actor }}
+          RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Create release
         uses: softprops/action-gh-release@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: mvn -B clean package -DskipTests
 
       - name: Publish to GitHub Packages
-        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true -DretryFailedDeploymentCount=1 -Dmaven.deploy.skip=false deploy -pl api,omod
         env:
           RELEASE_USERNAME: ${{ github.actor }}
           RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -126,3 +126,18 @@ If uploads are not allowed from the web (changable via a runtime property), you 
 into the ~/.OpenMRS/modules folder.  (Where ~/.OpenMRS is assumed to be the Application 
 Data Directory that the running openmrs is currently using.)  After putting the file in there 
 simply restart OpenMRS/tomcat and the module will be loaded and started.
+
+Releasing
+---------
+Releases are automated via GitHub Actions. To create a new release:
+
+1. Go to the **Actions** tab in this repository.
+2. Select the **Release** workflow from the left sidebar.
+3. Click **Run workflow**.
+4. Enter the release version (e.g. `1.1.5`) and click **Run workflow**.
+
+The workflow will:
+- Set the version in the POM to the release version.
+- Build the module and produce the `.omod` file.
+- Create a GitHub release with the `.omod` attached.
+- Bump the POM version to the next SNAPSHOT (e.g. `1.1.6-SNAPSHOT`) and push to main.


### PR DESCRIPTION
The parent POM (santedb-mpiclient:pom) was already uploaded to GitHub Packages during a previous release attempt. GitHub Packages does not allow overwriting existing artifacts, so subsequent deploys fail with 409 Conflict. This adds `-pl api,omod` to only deploy the submodules, skipping the parent POM.