### PR TITLE
Fix release deploy: use s4u/maven-settings-action and skip parent POM

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -156,9 +156,9 @@
                                     <repositoryId>github-packages</repositoryId>
                                     <packaging>omod</packaging>
                                     <generatePom>false</generatePom>
-                                    <artifactId>${project.parent.artifactId}</artifactId>
+                                    <artifactId>${project.parent.artifactId}-omod</artifactId>
                                     <version>${project.version}</version>
-                                    <groupId>${groupId}</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
The \`deploy-file\` execution in \`omod/pom.xml\` uploads the \`.omod\` file using the parent's \`artifactId\` (\`santedb-mpiclient\`). Since the parent module's default deploy already uploads \`org.openmrs.module:santedb-mpiclient:pom\`, the \`deploy-file\` tries to upload to the same coordinates and GitHub Packages rejects it with 409 Conflict.

Changed the \`deploy-file\` artifactId from \`\${project.parent.artifactId}\` to \`\${project.parent.artifactId}-omod\` so the OMOD gets its own unique coordinates. Also fixes the deprecated \`\${groupId}\` expression to \`\${project.groupId}\`.