### PR TITLE
Fix 409 conflict on deploy: use distinct artifactId for omod deploy-file

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -144,6 +144,11 @@
                         <artifactId>maven-deploy-plugin</artifactId>
                         <executions>
                             <execution>
+                                <!-- Skip default deploy to avoid 409 with deploy-file -->
+                                <id>default-deploy</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
                                 <!-- Deploy OpenMRS omod file -->
                                 <id>deploy-file</id>
                                 <phase>deploy</phase>
@@ -158,7 +163,7 @@
                                     <generatePom>false</generatePom>
                                     <artifactId>${project.parent.artifactId}</artifactId>
                                     <version>${project.version}</version>
-                                    <groupId>${groupId}</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
The deploy-file execution uses the parent's artifactId to upload the .omod file, which clashes with the parent POM already in the registry. Changed to ${project.parent.artifactId}-omod so the OMOD gets its own unique coordinates. Also fixes deprecated ${groupId} to ${project.groupId}.