### PR TITLE
fix(pdq): guard null otherDataPoints in loadSearchQuery

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -309,6 +309,9 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 			PatientIdentifier mothersIdentifier,
 			String nextOfKinName, String birthPlace,
 			Map<String, Object> otherDataPoints) throws MpiClientException {
+		if (otherDataPoints == null) {
+			otherDataPoints = new java.util.HashMap<String, Object>();
+		}
 		IQuery<IBaseBundle> query = this.getClient(true).search().forResource("Patient");
 
 		if (familyName != null && !familyName.isEmpty())


### PR DESCRIPTION
## Problem
`FhirMpiClientServiceImpl.loadSearchQuery` throws `NullPointerException` when `otherDataPoints` is null, aborting every FHIR PDQ patient search before any request is sent (and marking the transaction rollback-only).

It happens on the standard MPI similar-patient path: `registrationcore` calls `findPreciseSimilarPatients(patient, null, ...)`, so `otherDataPoints` arrives null, and `loadSearchQuery` dereferences it:
```java
String localBiometricSubjectId   = (String) otherDataPoints.get("localBiometricSubjectId");
String nationalBiometricSubjectId = (String) otherDataPoints.get("nationalBiometricSubjectId");
String phoneNumber               = (String) otherDataPoints.get("phoneNumber");
```
```
NullPointerException at FhirMpiClientServiceImpl.loadSearchQuery(...:349)
  ← searchPatient(...:230) ← MpiClientServiceImpl.searchPatient(...:91)
  ← registrationcore FhirSimilarPatientsSearcher.find(...:43)
```

## Fix
Treat a null `otherDataPoints` as an empty map at the top of `loadSearchQuery`. One guard; no behavior change when the map is supplied.

## Impact
FHIR PDQ patient search / MPI similar-patient lookup no longer NPEs when called without extra data points; the query is built and sent to the MPI as expected.