### PR TITLE
feat(golden-id): return OpenCR golden id (CRUID) to the EMR and store as ECID

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientUpdateWorker.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/aop/PatientUpdateWorker.java
@@ -136,6 +136,10 @@ public class PatientUpdateWorker extends Thread {
 						log.warn(String.format("Patient already has local identifier in domain %s", xrefDomain));
 				}
 			}
+
+			// Resolve the OpenCR golden record id (CRUID) and store it locally (e.g. as ECID) so the
+			// EMR holds the enterprise identity returned by the Client Registry after deduplication.
+			hieService.synchronizeGoldenRecordId(m_patient);
 		} catch (MpiClientException e) {
 			log.error(e);
 		} finally {

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
@@ -81,6 +81,16 @@ public interface MpiClientService extends OpenmrsService {
     void synchronizePatientEnterpriseId(Patient patient) throws MpiClientException;
 
     /**
+     * Resolve the OpenCR golden record id (CRUID) for a locally-registered patient, or null if none.
+     */
+    String getGoldenRecordId(Patient patient) throws MpiClientException;
+
+    /**
+     * Resolve the golden record id and store it locally (as the configured golden-record identifier type).
+     */
+    void synchronizeGoldenRecordId(Patient patient) throws MpiClientException;
+
+    /**
      * Import the specified patient data from the PDQ supplier
      * @param identifier
      * @param asigningAuthority

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -64,6 +64,11 @@ import org.hl7.fhir.r4.model.codesystems.LinkType;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.Location;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.fhir2.api.FhirPatientIdentifierSystemService;
+import org.openmrs.module.santedb.mpiclient.aop.PatientSynchronizationAdvice;
 import org.openmrs.PersonAttribute;
 import org.openmrs.module.fhir2.api.translators.PatientTranslator;
 import org.openmrs.module.santedb.mpiclient.api.MpiClientWorker;
@@ -758,5 +763,96 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * Resolve the OpenCR golden record id (CRUID) for a locally-registered patient: query the MPI by
+	 * the patient's iSantePlus ID, find the linked golden record (by golden tag), and follow any
+	 * replaced-by link to the surviving golden. Returns null when no golden record is found.
+	 */
+	public String getGoldenRecordId(Patient patient) {
+		try {
+			PatientIdentifier localId = patient.getPatientIdentifier("iSantePlus ID");
+			if (localId == null) {
+				log.warn("Patient has no iSantePlus ID; cannot resolve golden record id");
+				return null;
+			}
+			FhirPatientIdentifierSystemService sysService = Context.getService(FhirPatientIdentifierSystemService.class);
+			String system = sysService.getUrlByPatientIdentifierType(localId.getIdentifierType());
+			if (system == null || system.isEmpty()) {
+				log.warn("No FHIR identifier system mapped for iSantePlus ID; cannot resolve golden record id");
+				return null;
+			}
+
+			Bundle bundle = this.getClient(true).search()
+					.byUrl("Patient?identifier=" + system + "|" + localId.getIdentifier() + "&_include=Patient:link")
+					.returnBundle(Bundle.class).execute();
+
+			org.hl7.fhir.r4.model.Patient golden = null;
+			for (BundleEntryComponent entry : bundle.getEntry()) {
+				if (entry.getResource() instanceof org.hl7.fhir.r4.model.Patient) {
+					org.hl7.fhir.r4.model.Patient p = (org.hl7.fhir.r4.model.Patient) entry.getResource();
+					if (p.hasMeta() && p.getMeta().hasTag() && p.getMeta().getTagFirstRep().hasCode()
+							&& p.getMeta().getTagFirstRep().getCode().equals(m_configuration.getGoldenRecordUuid())) {
+						golden = p;
+						break;
+					}
+				}
+			}
+			if (golden == null) {
+				return null;
+			}
+
+			// If this golden was merged into another, follow the replaced-by link to the survivor.
+			for (PatientLinkComponent link : golden.getLink()) {
+				if (link.getType() != null && "replaced-by".equalsIgnoreCase(link.getType().toCode())
+						&& link.getOther() != null && link.getOther().getReferenceElement().hasIdPart()) {
+					return link.getOther().getReferenceElement().getIdPart();
+				}
+			}
+			return golden.getIdElement().getIdPart();
+		}
+		catch (Exception e) {
+			log.error("Error resolving golden record id", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Resolve the golden record id and store it on the patient as the configured golden-record
+	 * identifier type (default ECID). Suppresses the export advice so the write does not re-trigger a feed.
+	 */
+	public void synchronizeGoldenRecordId(Patient patient) {
+		String goldenId = this.getGoldenRecordId(patient);
+		if (goldenId == null || goldenId.isEmpty()) {
+			return;
+		}
+		PatientIdentifierType type = Context.getPatientService()
+				.getPatientIdentifierTypeByName(m_configuration.getGoldenRecordIdentifierType());
+		if (type == null) {
+			log.warn(String.format("Golden-record identifier type '%s' not found; cannot store golden id",
+					m_configuration.getGoldenRecordIdentifierType()));
+			return;
+		}
+		PatientIdentifier existing = patient.getPatientIdentifier(type);
+		if (existing != null && goldenId.equals(existing.getIdentifier())) {
+			return;
+		}
+		boolean prev = PatientSynchronizationAdvice.SUPPRESS.get();
+		PatientSynchronizationAdvice.SUPPRESS.set(true);
+		try {
+			if (existing != null) {
+				existing.setIdentifier(goldenId);
+				Context.getPatientService().savePatientIdentifier(existing);
+			} else {
+				Location loc = Context.getLocationService().getDefaultLocation();
+				PatientIdentifier pid = new PatientIdentifier(goldenId, type, loc);
+				pid.setPatient(patient);
+				Context.getPatientService().savePatientIdentifier(pid);
+			}
+		}
+		finally {
+			PatientSynchronizationAdvice.SUPPRESS.set(prev);
+		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
@@ -169,6 +169,19 @@ public class MpiClientServiceImpl extends BaseOpenmrsService
             throw new MpiClientException("Patient has been removed from the HIE");
     }
 
+    @Override
+    public String getGoldenRecordId(Patient patient) throws MpiClientException {
+        if (MpiClientConfiguration.getInstance().getMessageFormat().equals("fhir"))
+            return this.m_fhirService.getGoldenRecordId(patient);
+        return null;
+    }
+
+    @Override
+    public void synchronizeGoldenRecordId(Patient patient) throws MpiClientException {
+        if (MpiClientConfiguration.getInstance().getMessageFormat().equals("fhir"))
+            this.m_fhirService.synchronizeGoldenRecordId(patient);
+    }
+
     /**
      * Import patient with specified patient data
      */

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/configuration/MpiClientConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/configuration/MpiClientConfiguration.java
@@ -415,6 +415,8 @@ public class MpiClientConfiguration {
 
 	private static final String PROP_NAME_GOLDEN_RECORD_UUID_ATTRIBUTE_NAME = "mpi-client.goldenRecordUuid";
 
+	private static final String PROP_NAME_GOLDEN_RECORD_TYPE = "mpi-client.pid.goldenRecordType";
+
 	public String getRegistrationConceptUuid() {
 		return this.getOrCreateGlobalProperty(PROP_NAME_REG_CONCEPT, "165194AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 	}
@@ -425,6 +427,13 @@ public class MpiClientConfiguration {
 
 	public String getGoldenRecordUuid() {
 		return this.getOrCreateGlobalProperty(PROP_NAME_GOLDEN_RECORD_UUID_ATTRIBUTE_NAME, "5c827da5-4858-4f3d-a50c-62ece001efea");
+	}
+
+	/**
+	 * Local patient identifier type in which to store the resolved OpenCR golden record id (CRUID).
+	 */
+	public String getGoldenRecordIdentifierType() {
+		return this.getOrCreateGlobalProperty(PROP_NAME_GOLDEN_RECORD_TYPE, "ECID");
 	}
 
 	public String getEmergencyContactConceptUuid() {


### PR DESCRIPTION
## What
After a patient is fed to OpenCR and deduplicated, resolve the **golden record id (CRUID)** and store it on the local patient as the **ECID** identifier — so the EMR holds the enterprise identity the Client Registry returns.

## How
- `MpiClientService.getGoldenRecordId(patient)` — queries OpenCR by the patient's iSantePlus ID, finds the linked golden record (by golden tag), and **follows `replaced-by`** to the surviving golden on merges. Returns null if unmatched.
- `MpiClientService.synchronizeGoldenRecordId(patient)` — resolves it and stores it as the identifier type configured by `mpi-client.pid.goldenRecordType` (default **ECID**), suppressing the export advice so the write does not re-trigger a feed.
- Wired into `PatientUpdateWorker` — runs on patient save after the PIX feed, so registration automatically stamps the golden id locally.
- New config: `mpi-client.pid.goldenRecordType` (default `ECID`).

## Notes
- Reuses the existing golden-record recognition (`mpi-client.goldenRecordUuid`).
- FHIR path only; no-op for the HL7 path.
- Builds on the merged PDQ null-otherDataPoints fix (#67).