### PR TITLE
feat(golden-id): list cross-facility occurrences from the golden record

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
@@ -91,6 +91,13 @@ public interface MpiClientService extends OpenmrsService {
     void synchronizeGoldenRecordId(Patient patient) throws MpiClientException;
 
     /**
+     * Return every source record linked to this patient's golden record across sites (the cross-facility
+     * occurrences), resolved directly from the golden's links rather than a demographic search. Empty if
+     * no golden is found or the MPI is unreachable.
+     */
+    List<MpiPatient> getGoldenRecordOccurrences(Patient patient) throws MpiClientException;
+
+    /**
      * Import the specified patient data from the PDQ supplier
      * @param identifier
      * @param asigningAuthority

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -67,7 +67,6 @@ import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.fhir2.api.FhirPatientIdentifierSystemService;
 import org.openmrs.module.santedb.mpiclient.aop.PatientSynchronizationAdvice;
 import org.openmrs.PersonAttribute;
 import org.openmrs.module.fhir2.api.translators.PatientTranslator;
@@ -777,10 +776,24 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 				log.warn("Patient has no iSantePlus ID; cannot resolve golden record id");
 				return null;
 			}
-			FhirPatientIdentifierSystemService sysService = Context.getService(FhirPatientIdentifierSystemService.class);
-			String system = sysService.getUrlByPatientIdentifierType(localId.getIdentifierType());
+			// Resolve the FHIR identifier system the SAME way the export does: from the fhir2
+			// PatientTranslator output. This guarantees the query system matches exactly what was fed
+			// to OpenCR, and avoids a hard dependency on FhirPatientIdentifierSystemService, which is
+			// not registered on all fhir2 versions.
+			String system = null;
+			try {
+				org.hl7.fhir.r4.model.Patient fhirPatient = this.patientTranslator.toFhirResource(patient);
+				for (org.hl7.fhir.r4.model.Identifier fhirId : fhirPatient.getIdentifier()) {
+					if (fhirId.hasSystem() && localId.getIdentifier().equals(fhirId.getValue())) {
+						system = fhirId.getSystem();
+						break;
+					}
+				}
+			} catch (Exception e) {
+				log.warn("Could not translate patient to resolve identifier system", e);
+			}
 			if (system == null || system.isEmpty()) {
-				log.warn("No FHIR identifier system mapped for iSantePlus ID; cannot resolve golden record id");
+				log.warn("No FHIR identifier system for iSantePlus ID; cannot resolve golden record id");
 				return null;
 			}
 

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -862,22 +862,33 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 					continue;
 				}
 
-				MpiPatient mpiPatient = fhirUtil.parseFhirPatient(p, patientTranslator.toOpenmrsType(p));
+				// Parse each occurrence independently so one unparseable record does not drop the whole
+				// list. The fhir2 (1.11.x) address translator throws NPEs on some source address
+				// structures (e.g. consolidated-server records); we do not display address here, so drop
+				// it before translating to avoid that failure.
+				try {
+					p.setAddress(new java.util.ArrayList<org.hl7.fhir.r4.model.Address>());
 
-				// Derive a site label from the first identifier that carries a location extension.
-				for (org.hl7.fhir.r4.model.Identifier fhirId : p.getIdentifier()) {
-					org.hl7.fhir.r4.model.Extension locExt = fhirId
-							.getExtensionByUrl("http://fhir.openmrs.org/ext/patient/identifier#location");
-					if (locExt != null && locExt.getValue() instanceof org.hl7.fhir.r4.model.Reference) {
-						String site = ((org.hl7.fhir.r4.model.Reference) locExt.getValue()).getDisplay();
-						if (site != null && !site.isEmpty()) {
-							mpiPatient.setSourceLocation(site);
-							break;
+					MpiPatient mpiPatient = fhirUtil.parseFhirPatient(p, patientTranslator.toOpenmrsType(p));
+
+					// Derive a site label from the first identifier that carries a location extension.
+					for (org.hl7.fhir.r4.model.Identifier fhirId : p.getIdentifier()) {
+						org.hl7.fhir.r4.model.Extension locExt = fhirId
+								.getExtensionByUrl("http://fhir.openmrs.org/ext/patient/identifier#location");
+						if (locExt != null && locExt.getValue() instanceof org.hl7.fhir.r4.model.Reference) {
+							String site = ((org.hl7.fhir.r4.model.Reference) locExt.getValue()).getDisplay();
+							if (site != null && !site.isEmpty()) {
+								mpiPatient.setSourceLocation(site);
+								break;
+							}
 						}
 					}
-				}
 
-				occurrences.add(mpiPatient);
+					occurrences.add(mpiPatient);
+				}
+				catch (Exception perRecord) {
+					log.warn("Skipping an occurrence that could not be parsed", perRecord);
+				}
 			}
 		}
 		catch (Exception e) {

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -832,6 +832,61 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 	}
 
 	/**
+	 * Return every source record linked to the patient's golden record (the cross-facility occurrences),
+	 * resolved directly from the golden's links. Uses the resolved golden id, then fetches the golden with
+	 * {@code _include=Patient:link} so all linked source records come back in one bundle. The golden record
+	 * itself (which carries no demographics in this topology) is excluded; each occurrence's site is taken
+	 * from its identifier location extension when available.
+	 */
+	public List<MpiPatient> getGoldenRecordOccurrences(Patient patient) {
+		List<MpiPatient> occurrences = new java.util.ArrayList<MpiPatient>();
+		try {
+			String goldenId = this.getGoldenRecordId(patient);
+			if (goldenId == null || goldenId.isEmpty()) {
+				return occurrences;
+			}
+
+			Bundle bundle = this.getClient(true).search()
+					.byUrl("Patient?_id=" + goldenId + "&_include=Patient:link")
+					.returnBundle(Bundle.class).execute();
+
+			for (BundleEntryComponent entry : bundle.getEntry()) {
+				if (!(entry.getResource() instanceof org.hl7.fhir.r4.model.Patient)) {
+					continue;
+				}
+				org.hl7.fhir.r4.model.Patient p = (org.hl7.fhir.r4.model.Patient) entry.getResource();
+
+				// Skip the golden record itself (tagged with the golden uuid; carries no demographics).
+				if (p.hasMeta() && p.getMeta().hasTag() && p.getMeta().getTagFirstRep().hasCode()
+						&& p.getMeta().getTagFirstRep().getCode().equals(m_configuration.getGoldenRecordUuid())) {
+					continue;
+				}
+
+				MpiPatient mpiPatient = fhirUtil.parseFhirPatient(p, patientTranslator.toOpenmrsType(p));
+
+				// Derive a site label from the first identifier that carries a location extension.
+				for (org.hl7.fhir.r4.model.Identifier fhirId : p.getIdentifier()) {
+					org.hl7.fhir.r4.model.Extension locExt = fhirId
+							.getExtensionByUrl("http://fhir.openmrs.org/ext/patient/identifier#location");
+					if (locExt != null && locExt.getValue() instanceof org.hl7.fhir.r4.model.Reference) {
+						String site = ((org.hl7.fhir.r4.model.Reference) locExt.getValue()).getDisplay();
+						if (site != null && !site.isEmpty()) {
+							mpiPatient.setSourceLocation(site);
+							break;
+						}
+					}
+				}
+
+				occurrences.add(mpiPatient);
+			}
+		}
+		catch (Exception e) {
+			log.error("Error resolving golden record occurrences", e);
+		}
+		return occurrences;
+	}
+
+	/**
 	 * Resolve the golden record id and store it on the patient as the configured golden-record
 	 * identifier type (default ECID). Suppresses the export advice so the write does not re-trigger a feed.
 	 */

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
@@ -182,6 +182,13 @@ public class MpiClientServiceImpl extends BaseOpenmrsService
             this.m_fhirService.synchronizeGoldenRecordId(patient);
     }
 
+    @Override
+    public List<MpiPatient> getGoldenRecordOccurrences(Patient patient) throws MpiClientException {
+        if (MpiClientConfiguration.getInstance().getMessageFormat().equals("fhir"))
+            return this.m_fhirService.getGoldenRecordOccurrences(patient);
+        return new java.util.ArrayList<MpiPatient>();
+    }
+
     /**
      * Import patient with specified patient data
      */


### PR DESCRIPTION
Adds MpiClientService.getGoldenRecordOccurrences(Patient): resolves the patient's golden record id, then fetches the golden with _include=Patient:link and returns every linked source record (the cross-facility occurrences), excluding the bare golden record. Each occurrence's site is taken from its identifier location extension when present.

This replaces using the demographic PDQ searchPatient for the after-save "matches" view, which was unreliable in the demographics-out-of-golden topology (returned the patient themselves, or empty when multiple sources existed under one golden).

Builds on the fhir2-compat fix (#69).