### PR TITLE
fix(fhir search): skip untranslatable MPI patients so one bad record doesn't fail the whole search

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -287,11 +287,19 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 							&& gr.hasLink()) {
 						for (PatientLinkComponent grPatLink : gr.getLink()) {
 							if (grPatLink.getOther().getResource() != null) {
-
-								MpiPatient mpiPatient = fhirUtil.parseFhirPatient((org.hl7.fhir.r4.model.Patient) grPatLink.getOther().getResource(), patientTranslator.toOpenmrsType(
-										(org.hl7.fhir.r4.model.Patient) grPatLink.getOther().getResource()));
-
-								retVal.add(mpiPatient);
+								// Translate each linked source patient in isolation: a single
+								// untranslatable record (e.g. a cross-facility identifier type not
+								// present locally) must not fail the whole search result set.
+								try {
+									org.hl7.fhir.r4.model.Patient sourcePatient =
+											(org.hl7.fhir.r4.model.Patient) grPatLink.getOther().getResource();
+									MpiPatient mpiPatient = fhirUtil.parseFhirPatient(sourcePatient,
+											patientTranslator.toOpenmrsType(sourcePatient));
+									retVal.add(mpiPatient);
+								} catch (Exception ex) {
+									log.error("Skipping untranslatable MPI patient "
+											+ grPatLink.getOther().getReference(), ex);
+								}
 							}
 						}
 


### PR DESCRIPTION
## Problem
FHIR-mode MPI search (`searchPatient` → `getMpiPatientMatches`) fails **wholesale** whenever a single linked source patient can't be translated. In production, `searchMpi` from the EMR returned `mpiError: true` even though both OpenCR requests succeeded (verified via the OpenHIM transaction log):

```
GET /CR/fhir/Patient?family:contains=Pierre&_format=json                      -> 200
GET /CR/fhir/Patient?_id=<golden uuids>&_include=Patient:link&_format=json     -> 200
```

Auth, endpoints and queries are all fine — the exception is thrown **in Java**, while translating a linked source patient via `patientTranslator.toOpenmrsType(...)` (e.g. a cross-facility record whose identifier type/system isn't resolvable locally). Because the translation loop had no per-record guard, one bad patient aborted the entire result set.

## Fix
Wrap each linked source patient's translation in its own `try/catch`. A record that fails to translate is now logged (with its reference) and skipped, so the search returns every patient that *does* translate instead of failing completely. The log line also surfaces the exact translation defect for follow-up.

## Testing
- `mvn clean package` builds green.
- Reproduced the two OpenCR requests directly (both 200) to confirm the failure is in translation, not transport/auth.
