### PR TITLE
fix(export): PUT patient by id instead of conditional-update so EMR writes reach OpenCR

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -710,25 +710,19 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 						.setValue(sourceKey);
 			}
 
-			MethodOutcome result;
-			if (sourceKey != null) {
-				// Conditional update on the source-key: creates if new, updates the existing source
-				// otherwise, so a patient fed by both paths does not produce a duplicate source.
-				result = client.update().resource(admitMessage)
-						.conditional()
-						.where(org.hl7.fhir.r4.model.Patient.IDENTIFIER.exactly()
-								.systemAndIdentifier(this.m_configuration.getSourceKeySystem(), sourceKey))
-						.execute();
-				// A conditional update returns created=false when it updates; treat only a missing
-				// id/resource as a failure.
-				if (result.getId() == null && result.getResource() == null)
-					throw new MpiClientException("Error from MPI :> source-key upsert returned no id");
-			} else {
-				result = client.create().resource(admitMessage).execute();
-				if (!result.getCreated())
-					throw new MpiClientException(
-							String.format("Error from MPI :> %s", result.getResource().getClass().getName()));
+			// OpenCR does NOT support FHIR conditional-update (PUT /Patient?identifier=...): it
+			// responds 404 "Cannot PUT /fhir/Patient". PUT by a stable id (the patient uuid) instead
+			// -- OpenCR matches/dedupes on the in-resource source-key identifier, so this is
+			// idempotent and converges with the consolidated batch feed, which also PUTs by id (see
+			// the fhir-router mediator). The source-key identifier added above is what makes both
+			// feeds resolve to a single source record.
+			String stableId = patientExport.getPatient().getUuid();
+			if (stableId != null && !stableId.isEmpty()) {
+				admitMessage.setId(stableId);
 			}
+			MethodOutcome result = client.update().resource(admitMessage).execute();
+			if (result.getId() == null && result.getResource() == null)
+				throw new MpiClientException("Error from MPI :> patient upsert returned no id");
 
 		}
 		catch (FhirClientConnectionException e) {


### PR DESCRIPTION
## Problem
The real-time EMR → Client Registry (OpenCR) write path is broken. When a patient is saved, `exportPatient` issues a FHIR **conditional update**:

```
PUT /CR/fhir/Patient?identifier=http://sedish-haiti.org/fhir/source-key|<mspp-id>&_format=json
```

OpenCR does not support conditional update and responds **404** with `Cannot PUT /fhir/Patient`, so the patient never reaches the registry in real time (it only lands later via the consolidated batch feed).

Verified directly against the live OpenCR:
- `PUT /Patient?identifier=...` (conditional) → **404** `Cannot PUT /fhir/Patient`
- `PUT /Patient/{id}` (by id) → **200 OK**, and OpenCR runs matching and creates the golden record.

## Fix
Write by a **stable id** (the patient uuid) instead of a conditional update:

```java
admitMessage.setId(patientExport.getPatient().getUuid());
MethodOutcome result = client.update().resource(admitMessage).execute();   // PUT /Patient/{uuid}
```

OpenCR matches/dedupes on the in-resource **source-key** identifier (still added above), so this is idempotent and converges with the consolidated batch feed — which already PUTs by id via the fhir-router mediator. This mirrors that mediator's documented approach ("OpenCR does NOT support FHIR conditional-update, so we PUT by id").

## Testing
- `mvn clean package` green.
- Confirmed the two PUT styles above against the live OpenCR channel (conditional 404s, by-id 200 + golden created).

Builds on #73 (resilient search translation), which remains intact.
