### PR TITLE
Export write-path fixes: PUT-by-id + sanitize exported identifiers

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -710,25 +710,19 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 						.setValue(sourceKey);
 			}
 
-			MethodOutcome result;
-			if (sourceKey != null) {
-				// Conditional update on the source-key: creates if new, updates the existing source
-				// otherwise, so a patient fed by both paths does not produce a duplicate source.
-				result = client.update().resource(admitMessage)
-						.conditional()
-						.where(org.hl7.fhir.r4.model.Patient.IDENTIFIER.exactly()
-								.systemAndIdentifier(this.m_configuration.getSourceKeySystem(), sourceKey))
-						.execute();
-				// A conditional update returns created=false when it updates; treat only a missing
-				// id/resource as a failure.
-				if (result.getId() == null && result.getResource() == null)
-					throw new MpiClientException("Error from MPI :> source-key upsert returned no id");
-			} else {
-				result = client.create().resource(admitMessage).execute();
-				if (!result.getCreated())
-					throw new MpiClientException(
-							String.format("Error from MPI :> %s", result.getResource().getClass().getName()));
+			// OpenCR does NOT support FHIR conditional-update (PUT /Patient?identifier=...): it
+			// responds 404 "Cannot PUT /fhir/Patient". PUT by a stable id (the patient uuid) instead
+			// -- OpenCR matches/dedupes on the in-resource source-key identifier, so this is
+			// idempotent and converges with the consolidated batch feed, which also PUTs by id (see
+			// the fhir-router mediator). The source-key identifier added above is what makes both
+			// feeds resolve to a single source record.
+			String stableId = patientExport.getPatient().getUuid();
+			if (stableId != null && !stableId.isEmpty()) {
+				admitMessage.setId(stableId);
 			}
+			MethodOutcome result = client.update().resource(admitMessage).execute();
+			if (result.getId() == null && result.getResource() == null)
+				throw new MpiClientException("Error from MPI :> patient upsert returned no id");
 
 		}
 		catch (FhirClientConnectionException e) {

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -57,6 +57,7 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient.PatientLinkComponent;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
@@ -104,6 +105,11 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 
 	// Log
 	private static final Log log = LogFactory.getLog(HL7MpiClientServiceImpl.class);
+
+	// A bare UUID is never a valid site/person identifier value — it's an internal MPI id (golden
+	// CRUID, ECID, or a source-record uuid). Such values must not be exported to the registry.
+	private static final java.util.regex.Pattern UUID_VALUE =
+	        java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
 	// Get health information exchange information
 	private final MpiClientConfiguration m_configuration = MpiClientConfiguration.getInstance();
@@ -651,6 +657,27 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 		try {
 			admitMessage = patientTranslator.toFhirResource(patientExport.getPatient());
 			admitMessage.getNameFirstRep().setUse(HumanName.NameUse.OFFICIAL);
+
+			// Sanitize the exported identifier set so we never propagate corruption to the registry:
+			//   - drop UUID-valued ids (the local ECID/golden id and any imported record uuid — these
+			//     are internal MPI ids, not site identifiers),
+			//   - drop blanks, and dedupe by system (keep the first value per system).
+			// The site source-key is added fresh below, so it is unaffected. PUT-by-id then REPLACES
+			// the OpenCR resource with this clean set (no accumulation across re-exports).
+			List<Identifier> cleanedIds = new ArrayList<Identifier>();
+			Set<String> seenIdSystems = new HashSet<String>();
+			for (Identifier id : admitMessage.getIdentifier()) {
+				String sys = id.getSystem();
+				String val = id.getValue();
+				if (val == null || val.isEmpty() || UUID_VALUE.matcher(val).matches()) {
+					continue;
+				}
+				if (sys != null && !sys.isEmpty() && !seenIdSystems.add(sys)) {
+					continue;
+				}
+				cleanedIds.add(id);
+			}
+			admitMessage.setIdentifier(cleanedIds);
 
 			//           Set mother's name
 			if (patientExport.getMothersMaidenName() != null) {


### PR DESCRIPTION
Two fixes to the EMR → Client Registry (OpenCR) write path:

1. **PUT-by-id** instead of FHIR conditional-update (OpenCR 404s on `PUT /Patient?identifier=...`). Idempotent upsert keyed on the in-resource source-key, converging with the batch feed.
2. **Sanitize the exported identifier set** in `exportPatient`: drop UUID-valued identifiers (the local ECID/golden id and any imported record UUID — internal MPI ids, never site identifiers) and dedupe by system, before the PUT. Prevents re-exports from corrupting the OpenCR source record with UUID-valued ids and duplicates.

Root-cause context: records had accumulated multiple source-keys, duplicate identifiers, and UUID-valued identifiers because the local record picked up foreign ids (import) and export shipped them verbatim. Paired with an import-side fix in the iSantePlus module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)