### PR TITLE
Occurrences: exclude local record + view by golden id

### DIFF
--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/MpiClientService.java
@@ -98,6 +98,12 @@ public interface MpiClientService extends OpenmrsService {
     List<MpiPatient> getGoldenRecordOccurrences(Patient patient) throws MpiClientException;
 
     /**
+     * List every source record under a golden record (CRUID) directly, independent of any local
+     * patient record. Empty if the golden is not found or the MPI is unreachable.
+     */
+    List<MpiPatient> getGoldenRecordOccurrencesByGoldenId(String goldenId) throws MpiClientException;
+
+    /**
      * Import the specified patient data from the PDQ supplier
      * @param identifier
      * @param asigningAuthority

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/FhirMpiClientServiceImpl.java
@@ -965,9 +965,23 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 	 * from its identifier location extension when available.
 	 */
 	public List<MpiPatient> getGoldenRecordOccurrences(Patient patient) {
+		// Records at OTHER facilities: resolve this patient's golden, then list its sources excluding
+		// the local EMR's own copy (OpenCR holds it under the local patient uuid, set at export time).
+		String goldenId = this.getGoldenRecordId(patient);
+		return occurrencesForGolden(goldenId, patient != null ? patient.getUuid() : null);
+	}
+
+	/**
+	 * List every source record under a golden record (CRUID) directly — for viewing a patient's
+	 * registry record by golden id, independent of any local patient record.
+	 */
+	public List<MpiPatient> getGoldenRecordOccurrencesByGoldenId(String goldenId) {
+		return occurrencesForGolden(goldenId, null);
+	}
+
+	private List<MpiPatient> occurrencesForGolden(String goldenId, String excludeSourceId) {
 		List<MpiPatient> occurrences = new java.util.ArrayList<MpiPatient>();
 		try {
-			String goldenId = this.getGoldenRecordId(patient);
 			if (goldenId == null || goldenId.isEmpty()) {
 				return occurrences;
 			}
@@ -985,6 +999,11 @@ public class FhirMpiClientServiceImpl implements MpiClientWorker, ApplicationCon
 				// Skip the golden record itself (tagged with the golden uuid; carries no demographics).
 				if (p.hasMeta() && p.getMeta().hasTag() && p.getMeta().getTagFirstRep().hasCode()
 						&& p.getMeta().getTagFirstRep().getCode().equals(m_configuration.getGoldenRecordUuid())) {
+					continue;
+				}
+
+				// Skip the local EMR's own copy when requested — occurrences list OTHER facilities only.
+				if (excludeSourceId != null && excludeSourceId.equals(p.getIdElement().getIdPart())) {
 					continue;
 				}
 

--- a/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/santedb/mpiclient/api/impl/MpiClientServiceImpl.java
@@ -189,6 +189,12 @@ public class MpiClientServiceImpl extends BaseOpenmrsService
         return new java.util.ArrayList<MpiPatient>();
     }
 
+    public List<MpiPatient> getGoldenRecordOccurrencesByGoldenId(String goldenId) throws MpiClientException {
+        if (MpiClientConfiguration.getInstance().getMessageFormat().equals("fhir"))
+            return this.m_fhirService.getGoldenRecordOccurrencesByGoldenId(goldenId);
+        return new java.util.ArrayList<MpiPatient>();
+    }
+
     /**
      * Import patient with specified patient data
      */


### PR DESCRIPTION
getGoldenRecordOccurrences now excludes the local EMR's own copy (matched by the local patient uuid, which the export writes as the OpenCR source id) — so the cross-facility occurrences list shows OTHER sites only. Adds getGoldenRecordOccurrencesByGoldenId(String) to list a golden's sources directly by CRUID (for viewing a registry record independent of a local patient). Base: roaming-care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)